### PR TITLE
Prevent unwanted font-family change

### DIFF
--- a/html2pdf.class.php
+++ b/html2pdf.class.php
@@ -3340,6 +3340,9 @@ if (!defined('__CLASS_HTML2PDF__')) {
 
                 if (strlen($str[0])) {
                     $this->pdf->setXY($this->pdf->getX(), $y+$dh+$dy);
+                    if($this->pdf->getFontFamily() != $this->parsingCss->value['font-family']) {
+                        $this->pdf->SetFont($this->_defaultFont);
+                    }
                     $this->pdf->Cell($wc, $h, $str[0], 0, 0, $align, $fill, $this->_isInLink);
                     $this->pdf->setXY($this->pdf->getX(), $y);
                 }
@@ -3406,6 +3409,9 @@ if (!defined('__CLASS_HTML2PDF__')) {
                 $txt = ''; foreach ($words as $k => $word) $txt.= ($k ? ' ' : '').$word[0];
                 $w+= $this->pdf->getWordSpacing()*(count($words));
                 $this->pdf->setXY($this->pdf->getX(), $y+$dh+$dy);
+                if($this->pdf->getFontFamily() != $this->parsingCss->value['font-family']) {
+                    $this->pdf->SetFont($this->_defaultFont);
+                }
                 $this->pdf->Cell(($align=='L' ? $w : $this->parsingCss->value['width']), $h, $txt, 0, 0, $align, $fill, $this->_isInLink);
                 $this->pdf->setXY($this->pdf->getX(), $y);
                 $this->_maxH = max($this->_maxH, $lh);


### PR DESCRIPTION
When writing `<page_header>` and `<page_footer>` tags, the TCPDF object reverts to its default font (`helvetica`) instead of the HTML2PDF default font that can be set by the user. This is generally harmless, but when the header or footer text contains characters unavailable in Helvetica, they appear as question marks in the generated PDF.

This fix makes sure that the font used when writing text is ALWAYS the one defined by CSS.

Fixes #1
