### PR TITLE
Make space-collapsing regexp Unicode-aware for IIS compatibility

### DIFF
--- a/_class/parsingHtml.class.php
+++ b/_class/parsingHtml.class.php
@@ -231,7 +231,7 @@ class HTML2PDF_parsingHtml
      */
     protected function _prepareTxt($txt, $spaces = true)
     {
-        if ($spaces) $txt = preg_replace('/\s+/is', ' ', $txt);
+        if ($spaces) $txt = preg_replace('/\s+/isu', ' ', $txt);
         $txt = str_replace('&euro;', '€', $txt);
         $txt = html_entity_decode($txt, ENT_QUOTES, $this->_encoding);
         return $txt;


### PR DESCRIPTION
On Windows servers, the regexp needs to be made explicitly unicode-aware otherwise it garbles characters preceded by a space. This happens with Greek and Japanese for instance.