### PR TITLE
Create composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,27 @@
+{
+    "name": "spipu/html2pdf",
+    "type": "library",
+    "description": "Html2pdf' with Composer support. (Fixed composer dependency problem)",
+    "keywords": ["html", "pdf", "html2pdf"],
+    "homepage": "http://html2pdf.fr/",
+    "license": "LGPL",
+    "authors":
+    [
+        {
+            "name": "Spipu",
+            "homepage": "https://github.com/spipu",
+            "role": "Developer"
+        }
+    ],
+    "require":
+    {
+        "php": ">=5.2"
+    },
+    "autoload":
+    {
+        "psr-0":
+        {
+            "HTML2PDF": "."
+        }
+    }
+}


### PR DESCRIPTION
Adding a composer file.
Then the project should be registred to https://packagist.org/ to be officially available

We could probably add as dependency the package : tecnick.com/tcpdf instead of embedding it.