### PR TITLE
Update autoload type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,6 @@
     },
     "autoload":
     {
-        "psr-0":
-        {
-            "HTML2PDF": "."
-        }
+        "files": ["html2pdf.class.php"]
     }
 }


### PR DESCRIPTION
html2pdf doesn't follow `psr-0` because the composer can't autoload automatically this library, on the other hand using "files" key the composer can properly autoload the main file `html2pdf.class.php`.