### PR TITLE
Fixing a typo, array_key_exist() should be array_key_exists()

### DIFF
--- a/html2pdf.class.php
+++ b/html2pdf.class.php
@@ -2241,7 +2241,7 @@ if (!defined('__CLASS_HTML2PDF__')) {
 
             $resetPageNumber = (isset($param['pagegroup']) && $param['pagegroup']=='new');
             
-            if (array_key_exist('hideheader', $param) && $param['hideheader']!='false' && !empty($param['hideheader'])) {
+            if (array_key_exists('hideheader', $param) && $param['hideheader']!='false' && !empty($param['hideheader'])) {
                 $this->_hideHeader = (array) array_merge($this->_hideHeader, split(',', $param['hideheader']));
             }
 


### PR DESCRIPTION
I was in the neighborhood and thought I'd fix this typo, I'm using this code in a couple of my own projects and noticed this when cloning the most recent version. 