### PR TITLE
Improves composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
     {
         "php": ">=5.2"
     },
+    "suggest": {
+        "fagundes/zff-html2pdf": "zff-html2pdf module ~0.1.1, if you need to integrate HTML2PDF with Zend Framework 2 (zf2)"
+    },
     "autoload":
     {
         "files": ["html2pdf.class.php"]

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "spipu/html2pdf",
     "type": "library",
-    "description": "Html2pdf' with Composer support. (Fixed composer dependency problem)",
+    "description": "HTML2PDF is a HTML to PDF converter written in PHP4 (uses FPDF) and PHP5 (uses TCPDF).",
     "keywords": ["html", "pdf", "html2pdf"],
     "homepage": "http://html2pdf.fr/",
     "license": "LGPL",


### PR DESCRIPTION
Once the composer.json file is used to resolve package dependency, it's interesting to improve the library's description, it helps the library be found on [http://packagist.org](http://packagist.org).

I also add as a suggestion my own library which integrates HTML2PDF to ZendFramework 2. Of course, [zff-html2pdf](https://github.com/fagundes/zff-html2pdf) has as dependency the html2pdf.
