### PR TITLE
exception translation moved to formatter, add specific exceptions

### DIFF
--- a/src/Exception/ExceptionFormatter.php
+++ b/src/Exception/ExceptionFormatter.php
@@ -21,17 +21,71 @@ class ExceptionFormatter
     protected $htmlMessage;
 
     /**
-     * @param \Exception $e
+     * @param Html2PdfException $e
      */
-    public function __construct(\Exception $e)
+    public function __construct(Html2PdfException $e)
     {
-        $this->message = Locale::get('txt01', 'error: ').$e->getCode().' : '.strip_tags($e->getMessage());
+        $other = $e->getOther();
+        // read the error
+        switch ($e->getCode()) {
+            case 1: // Unsupported tag
+                $msg = (Locale::get('err01'));
+                $msg = str_replace('[[OTHER]]', $other, $msg);
+                break;
 
-        $this->buildHtmlMessage($e);
+            case 2: // too long sentence
+                $msg = (Locale::get('err02'));
+                $msg = str_replace('[[OTHER_0]]', $other[0], $msg);
+                $msg = str_replace('[[OTHER_1]]', $other[1], $msg);
+                $msg = str_replace('[[OTHER_2]]', $other[2], $msg);
+                break;
 
-        if ($e instanceof Html2PdfException) {
-            $this->appendHtmlContent($e->getHTML());
+            case 3: // closing tag in excess
+                $msg = (Locale::get('err03'));
+                $msg = str_replace('[[OTHER]]', $other, $msg);
+                break;
+
+            case 4: // tags closed in the wrong order
+                $msg = (Locale::get('err04'));
+                $msg = str_replace('[[OTHER]]', print_r($other, true), $msg);
+                break;
+
+            case 5: // unclosed tag
+                $msg = (Locale::get('err05'));
+                $msg = str_replace('[[OTHER]]', print_r($other, true), $msg);
+                break;
+
+            case 6: // image can not be loaded
+                $msg = (Locale::get('err06'));
+                $msg = str_replace('[[OTHER]]', $other, $msg);
+                break;
+
+            case 7: // too big TD content
+                $msg = (Locale::get('err07'));
+                break;
+
+            case 8: // SVG tag not in DRAW tag
+                $msg = (Locale::get('err08'));
+                $msg = str_replace('[[OTHER]]', $other, $msg);
+                break;
+
+            case 9: // deprecated
+                $msg = (Locale::get('err09'));
+                $msg = str_replace('[[OTHER_0]]', $other[0], $msg);
+                $msg = str_replace('[[OTHER_1]]', $other[1], $msg);
+                break;
+
+            case 0: // specific error
+            default:
+                $msg = $other;
+                break;
         }
+
+        $this->message = Locale::get('txt01', 'error: ').$e->getCode().' : '.strip_tags($msg);
+
+        $this->buildHtmlMessage($msg, $e);
+
+        $this->appendHtmlContent($e->getHTML());
     }
 
     /**
@@ -50,7 +104,7 @@ class ExceptionFormatter
         return $this->htmlMessage;
     }
 
-    protected function buildHtmlMessage(\Exception $e)
+    protected function buildHtmlMessage($msg, \Exception $e)
     {
         // create the HTML message
         $this->htmlMessage = '<span style="color: #AA0000; font-weight: bold;">'."\n";
@@ -58,7 +112,7 @@ class ExceptionFormatter
         $this->htmlMessage.= Locale::get('txt02', 'file:').' '.$e->getFile().'<br>'."\n";
         $this->htmlMessage.= Locale::get('txt03', 'line:').' '.$e->getLine().'<br>'."\n";
         $this->htmlMessage.= '<br>'."\n";
-        $this->htmlMessage.= $e->getMessage()."\n";
+        $this->htmlMessage.= $msg . "\n";
     }
 
     protected function appendHtmlContent($html)

--- a/src/Exception/HtmlParsingException.php
+++ b/src/Exception/HtmlParsingException.php
@@ -1,0 +1,9 @@
+<?php 
+
+namespace Spipu\Html2Pdf\Exception;
+
+use Spipu\Html2Pdf\Html2PdfException;
+
+class HtmlParsingException extends Html2PdfException
+{
+}

--- a/src/Exception/InvalidHtmlTagException.php
+++ b/src/Exception/InvalidHtmlTagException.php
@@ -1,0 +1,19 @@
+<?php 
+
+namespace Spipu\Html2Pdf\Exception;
+
+/**
+ * Class InvalidHtmlTagException
+ */
+class InvalidHtmlTagException extends HtmlParsingException
+{
+    /**
+     * @param int  $msg
+     * @param null $other
+     */
+    public function __construct($msg, $other = null)
+    {
+        $this->message = $msg;
+        parent::__construct(1, $other);
+    }
+}

--- a/src/Exception/UnclosedHtmlTagException.php
+++ b/src/Exception/UnclosedHtmlTagException.php
@@ -1,0 +1,12 @@
+<?php 
+
+namespace Spipu\Html2Pdf\Exception;
+
+class UnclosedHtmlTagException extends HtmlParsingException
+{
+    public function __construct($msg, $other = null)
+    {
+        $this->message = $msg;
+        parent::__construct(5, $other);
+    }
+}

--- a/src/Html2PdfException.php
+++ b/src/Html2PdfException.php
@@ -15,80 +15,28 @@ namespace Spipu\Html2Pdf;
 class Html2PdfException extends \Exception
 {
     protected $html = null;
+    protected $other = null;
 
     /**
      * generate a Html2Pdf exception
      *
-     * @param int    $err   error number
-     * @param mixed  $other additionnal informations
-     * @param string $html  additionnal informations
+     * @param int    $code  error code
+     * @param mixed  $other additional information
+     * @param string $html  additional information
      *
      * @return Html2PdfException
      */
-    final public function __construct($err = 0, $other = null, $html = '')
+    public function __construct($code = 0, $other = null, $html = '')
     {
-        // read the error
-        switch ($err) {
-            case 1: // Unsupported tag
-                $msg = (Locale::get('err01'));
-                $msg = str_replace('[[OTHER]]', $other, $msg);
-                break;
-
-            case 2: // too long sentence
-                $msg = (Locale::get('err02'));
-                $msg = str_replace('[[OTHER_0]]', $other[0], $msg);
-                $msg = str_replace('[[OTHER_1]]', $other[1], $msg);
-                $msg = str_replace('[[OTHER_2]]', $other[2], $msg);
-                break;
-
-            case 3: // closing tag in excess
-                $msg = (Locale::get('err03'));
-                $msg = str_replace('[[OTHER]]', $other, $msg);
-                break;
-
-            case 4: // tags closed in the wrong order
-                $msg = (Locale::get('err04'));
-                $msg = str_replace('[[OTHER]]', print_r($other, true), $msg);
-                break;
-
-            case 5: // unclosed tag
-                $msg = (Locale::get('err05'));
-                $msg = str_replace('[[OTHER]]', print_r($other, true), $msg);
-                break;
-
-            case 6: // image can not be loaded
-                $msg = (Locale::get('err06'));
-                $msg = str_replace('[[OTHER]]', $other, $msg);
-                break;
-
-            case 7: // too big TD content
-                $msg = (Locale::get('err07'));
-                break;
-
-            case 8: // SVG tag not in DRAW tag
-                $msg = (Locale::get('err08'));
-                $msg = str_replace('[[OTHER]]', $other, $msg);
-                break;
-
-            case 9: // deprecated
-                $msg = (Locale::get('err09'));
-                $msg = str_replace('[[OTHER_0]]', $other[0], $msg);
-                $msg = str_replace('[[OTHER_1]]', $other[1], $msg);
-                break;
-
-            case 0: // specific error
-            default:
-                $msg = $other;
-                break;
-        }
-
-        // add the optionnal html content
+        $this->other = $other;
+        // add the optional html content
         if ($html) {
             $this->html = $html;
         }
 
         // construct the exception
-        parent::__construct($msg, $err);
+        $msg = $this->message ? $this->message : 'Html2Pdf exception';
+        parent::__construct($msg, $code);
     }
 
     /**
@@ -111,5 +59,10 @@ class Html2PdfException extends \Exception
     public function getHTML()
     {
         return $this->html;
+    }
+
+    public function getOther()
+    {
+        return $this->other;
     }
 }

--- a/src/Parsing/Html.php
+++ b/src/Parsing/Html.php
@@ -11,7 +11,8 @@
  */
 namespace Spipu\Html2Pdf\Parsing;
 
-use Spipu\Html2Pdf\Html2PdfException;
+use Spipu\Html2Pdf\Exception\HtmlParsingException;
+use Spipu\Html2Pdf\Exception\UnclosedHtmlTagException;
 
 class Html
 {
@@ -119,9 +120,9 @@ class Html
                         if ($res['close']) {
                             // HTML validation
                             if (count($parents) < 1) {
-                                throw new Html2PdfException(3, $res['name'], $this->getHtmlErrorCode($res['html_pos']));
+                                throw new HtmlParsingException(3, $res['name'], $this->getHtmlErrorCode($res['html_pos']));
                             } elseif (end($parents) != $res['name']) {
-                                throw new Html2PdfException(4, $parents, $this->getHtmlErrorCode($res['html_pos']));
+                                throw new HtmlParsingException(4, $parents, $this->getHtmlErrorCode($res['html_pos']));
                             } else {
                                 array_pop($parents);
                             }
@@ -227,7 +228,7 @@ class Html
 
         // if we are not on the level 0 => HTML validator ERROR
         if (count($parents)) {
-            throw new Html2PdfException(5, $parents);
+            throw new UnclosedHtmlTagException('An HTML tag has not been closed', $parents);
         }
 
         // save the actions to do


### PR DESCRIPTION
also throw exception in _analyzeTag when the tag is malformed (instead of returning null) so we can simplify the parsing