### PR TITLE
do not update the font-family if the value is inherit

### DIFF
--- a/_class/parsingCss.class.php
+++ b/_class/parsingCss.class.php
@@ -611,7 +611,7 @@ class HTML2PDF_parsingCss
                 case 'font-family':
                     $val = explode(',', $val);
                     $val = trim($val[0]);
-                    if ($val) $this->value['font-family'] = $val;
+                    if ($val && $val != 'inherit') $this->value['font-family'] = $val;
                     break;
 
                 case 'font-weight':


### PR DESCRIPTION
Update for branch 4.5 (to report on master if ok)
If a CSS defines a font-family of 'inherit', TCPDF tries to load the "inherit" font name, leading to an exception. This change lets the css parser keep the old font-family value.