### PR TITLE
Trim string when preparing text.

### DIFF
--- a/_class/parsingHtml.class.php
+++ b/_class/parsingHtml.class.php
@@ -230,13 +230,15 @@ class HTML2PDF_parsingHtml
      * prepare the text
      *
      * @param   string $txt
-     * @param   boolean $spaces true => replace multiple space+\t+\r+\n by a single space
+     * @param   boolean $spaces true => trim and replace multiple space+\t+\r+\n by a single space
      * @return  string txt
      * @access  protected
      */
     protected function _prepareTxt($txt, $spaces = true)
     {
-        if ($spaces) $txt = preg_replace('/\s+/isu', ' ', $txt);
+        if ($spaces) {
+            $txt = preg_replace('/\s+/isu', ' ', trim($txt));
+        }
         $txt = str_replace('&euro;', '€', $txt);
         $txt = html_entity_decode($txt, ENT_QUOTES, $this->_encoding);
         return $txt;


### PR DESCRIPTION
If you have an HTML table cell like this:

```html
<td>
    <strong>
        Sum
    </strong>
</td>
```
html2pdf will put a space in front of "Sum" in the rendered PDF. But in HTML this does not happen, because texts are trimmed. This PR fixes the issue.