### PR TITLE
support the color attribute for the font tag

### DIFF
--- a/_class/parsingHtml.class.php
+++ b/_class/parsingHtml.class.php
@@ -404,6 +404,11 @@ class HTML2PDF_parsingHtml
                     }
                     $param[$key] = $val;
                     break;
+                case 'color':
+                    if ($name == 'font') {
+                        $param['style'] .= 'color: ' . $val . ';';
+                    }
+                    break;
             }
         }
 


### PR DESCRIPTION
When using <font color="#000000"> the color attribute is ignored.
Because <font> tags are included when using the HTML5 contenteditable API, it would be nice to support this attribute.