### PR TITLE
add pdfa support.

### DIFF
--- a/src/Html2Pdf.php
+++ b/src/Html2Pdf.php
@@ -160,7 +160,7 @@ class Html2Pdf
      * @param  array    $margins     Default margins (left, top, right, bottom)
      * @return Html2Pdf $this
      */
-    public function __construct($orientation = 'P', $format = 'A4', $lang = 'fr', $unicode = true, $encoding = 'UTF-8', $margins = array(5, 5, 5, 8))
+    public function __construct($orientation = 'P', $format = 'A4', $lang = 'fr', $unicode = true, $encoding = 'UTF-8', $margins = array(5, 5, 5, 8), $pdfa = false)
     {
         // init the page number
         $this->_page         = 0;
@@ -177,7 +177,7 @@ class Html2Pdf
         Locale::load($this->_langue);
 
         // create the  myPdf object
-        $this->pdf = new MyPdf($orientation, 'mm', $format, $unicode, $encoding);
+        $this->pdf = new MyPdf($orientation, 'mm', $format, $unicode, $encoding, false, $pdfa);
 
         // init the CSS parsing object
         $this->cssConverter = new CssConverter();

--- a/src/MyPdf.php
+++ b/src/MyPdf.php
@@ -44,11 +44,12 @@ class MyPdf extends \TCPDF
         $format = 'A4',
         $unicode = true,
         $encoding = 'UTF-8',
-        $diskcache = false
+        $diskcache = false,
+    	$pdfa = false
     ) {
     
         // call the parent constructor
-        parent::__construct($orientation, $unit, $format, $unicode, $encoding, $diskcache);
+        parent::__construct($orientation, $unit, $format, $unicode, $encoding, $diskcache, $pdfa);
 
         // init the specific parameters used by Html2Pdf
         $this->SetCreator(PDF_CREATOR);


### PR DESCRIPTION
for our project we need PDF/A-compatibility. In TCPDF you can control this by setting flag “pdfa” in the constructor of the class “TCPDF” to true, which works fine for us.  For this reason it would be great, if you give the possibility to add this feature in html2pdf. To reach this, it would be enough to extend the constructors of the classes “HTML2PDF” and “HTML2PDF_myPdf” with the optional Boolean parameter “pdfa”, which is not so much to do. What do you think about this?
