### PR TITLE
Added Dimension-Parameter (for PDF417, Datamatrix = 2D)

### DIFF
--- a/src/Html2Pdf.php
+++ b/src/Html2Pdf.php
@@ -3553,6 +3553,10 @@ class Html2Pdf
         if (isset($lstBarcode[$param['type']])) {
             $param['type'] = $lstBarcode[$param['type']];
         }
+        if (!isset($param['dimension'])) {
+            $param['dimension'] = '1D';
+        }
+ 
 
         $this->parsingCss->save();
         $this->parsingCss->analyse('barcode', $param);
@@ -3571,7 +3575,7 @@ class Html2Pdf
         }
         $txt = ($param['label']!=='none' ? $this->parsingCss->value['font-size'] : false);
         $c = $this->parsingCss->value['color'];
-        $infos = $this->pdf->myBarcode($param['value'], $param['type'], $x, $y, $w, $h, $txt, $c);
+        $infos = $this->pdf->myBarcode($param['value'], $param['type'], $x, $y, $w, $h, $txt, $c, $param['dimension']);
 
         $this->_maxX = max($this->_maxX, $x+$infos[0]);
         $this->_maxY = max($this->_maxY, $y+$infos[1]);

--- a/src/MyPdf.php
+++ b/src/MyPdf.php
@@ -1303,7 +1303,7 @@ class MyPdf extends \TCPDF
      * @param array $color color of the foreground
      * @access public
      */
-    public function myBarcode($code, $type, $x, $y, $w, $h, $labelFontsize, $color)
+    public function myBarcode($code, $type, $x, $y, $w, $h, $labelFontsize, $color, $dimension = '1D')
     {
         // the style of the barcode
         $style = array(
@@ -1314,7 +1314,12 @@ class MyPdf extends \TCPDF
         );
 
         // build the barcode
-        $this->write1DBarcode($code, $type, $x, $y, $w, $h, '', $style, 'N');
+        if ($dimension == '2D') {
+            // PDF417, DATAMATRIX ...
+            $this->write2DBarcode($code, $type, $x, $y, $w, $h, '', $style, 'N');
+        } else {
+            $this->write1DBarcode($code, $type, $x, $y, $w, $h, '', $style, 'N');
+        }
 
         // it Label => add the FontSize to the height
         if ($labelFontsize) {


### PR DESCRIPTION
`<barcode type="PDF417">` has caused an error: "TCPDF ERROR: Error in 1D barcode string".
`<barcode type="PDF417" dimension="2D">` will solve the problem.
