### PR TITLE
Cleanup install zip

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/examples/ export-ignore
+/test/ export-ignore
+/.* export-ignore
+/README.md export-ignore
+/phpunit.xml export-ignore
+/_changelog.txt export-ignore


### PR DESCRIPTION
What about removing examples, tests and other unnecessary documents for production machines?

People that wants those files can still get them by using `git clone --depth 1`, `composer require --prefer-source spipu/html2pdf` or github.

People that want just the necessary library files can use `composer require --prefer-dist spipu/html2pdf`.
This way:
- the production library size is smaller
- the production library does not contains useless files like tests/examples/...

You can see the power of this approach by comparing the current archive (https://github.com/mlocati/html2pdf/archive/master.zip) with what will be the new one (https://github.com/mlocati/html2pdf/archive/cleanup-install-zip.zip)
