### PR TITLE
Allow overriding K_PATH_FONTS to a custom dir

### DIFF
--- a/_class/tcpdfConfig.php
+++ b/_class/tcpdfConfig.php
@@ -113,7 +113,9 @@ if (!defined('K_TCPDF_EXTERNAL_CONFIG')) {
      * path for PDF fonts
      * use K_PATH_MAIN.'fonts/old/' for old non-UTF8 fonts
      */
-    define('K_PATH_FONTS', K_PATH_MAIN.'fonts/');
+    if (!defined('K_PATH_FONTS')) {
+        define('K_PATH_FONTS', K_PATH_MAIN.'fonts/');
+    }
 
     /**
      * cache directory for temporary files (url path)


### PR DESCRIPTION
It's against best practice to manually alter the contents on Composers' `vendor` directory.
In order to add fonts to TCPDF, files need to be added to the directory (conflicts with Composer) or the `K_PATH_FONTS` needs to be defined before loading TCPDF. HTML2PDF always defines this constant, causing code errors.
This change simply checks if the `K_PATH_FONTS` constant is already set and only defines it if not yet defined, making this work with Composer.
Please note that it'd be a good to copy atleast `helvetica.php` from `tcpdf/fonts` to the new directory, as this is the fallback font.