### PR TITLE
Page break Support via DIV-Element

### DIFF
--- a/src/Html2Pdf.php
+++ b/src/Html2Pdf.php
@@ -3487,6 +3487,11 @@ class Html2Pdf
      */
     protected function _tag_close_DIV($param, $other = 'div')
     {
+        if ($this->parsingCss->value['page-break-after'] == "always"){
+            $this->_setNewPage(null, '', null, $this->_defaultTop);
+            $this->parsingCss->setPosition();
+        }
+        
         if ($this->_isForOneLine) {
             return false;
         }

--- a/src/Parsing/Css.php
+++ b/src/Parsing/Css.php
@@ -181,6 +181,8 @@ class Css
 
         $this->value['xc'] = null;
         $this->value['yc'] = null;
+        
+        $this->value['page-break-after'] = null;
     }
 
     /**
@@ -1184,6 +1186,10 @@ class Css
 
                 case 'start':
                     $this->value[$nom] = intval($val);
+                    break;
+                    
+                case 'page-break-after':
+                    $this->value[$nom] = $val;
                     break;
 
                 default:


### PR DESCRIPTION
Issue:
https://github.com/spipu/html2pdf/issues/143

Solution (Thanh Trungs answer):
https://stackoverflow.com/questions/2117788/page-break-in-html2pdf

How to use:
` <div style="page-break-after:always;"></div>`