### PR TITLE
Skip name validation if destination is string

### DIFF
--- a/src/Html2Pdf.php
+++ b/src/Html2Pdf.php
@@ -531,9 +531,11 @@ class Html2Pdf
             throw new Html2PdfException('The output destination mode ['.$dest.'] is invalid');
         }
 
-        // the name must be a PDF name
-        if (strtolower(substr($name, -4)) !== '.pdf') {
-            throw new Html2PdfException('The output document name ['.$name.'] is not a PDF name');
+        if ($dest !== 'S') {
+            // the name must be a PDF name
+            if (strtolower(substr($name, -4)) !== '.pdf') {
+                throw new Html2PdfException('The output document name [' . $name . '] is not a PDF name');
+            }
         }
 
         // if save on server: it must be an absolute path


### PR DESCRIPTION
The documentation says that if the $dest parameter to Html2Pdf::output is 'S', the $name parameter will be ignored:

`S: return the document as a string (name is ignored).`

However, the code still insures that $name is a string that ends with ".pdf".

https://github.com/spipu/html2pdf/blob/1d565229d02eda85ceeb28e300ec596f75509bbd/src/Html2Pdf.php#L534-L537

This change removes the validation of the $name parameter when $dest is 'S'.