### PR TITLE
Increase radio/checkbox width

### DIFF
--- a/src/Html2Pdf.php
+++ b/src/Html2Pdf.php
@@ -5947,7 +5947,7 @@ class Html2Pdf
 
         switch ($param['type']) {
             case 'checkbox':
-                $w = 3;
+                $w = 4;
                 $h = $w;
                 if ($h<$f) {
                     $y+= ($f-$h)*0.5;
@@ -5957,7 +5957,7 @@ class Html2Pdf
                 break;
 
             case 'radio':
-                $w = 3;
+                $w = 4;
                 $h = $w;
                 if ($h<$f) {
                     $y+= ($f-$h)*0.5;


### PR DESCRIPTION
Hello,
When i try the form exemple, checkbox and radio buttons are cut. 
By changing width from 3 to 4, it's looks better.

I'am using Chrome Version 65.
Before :
![image](https://user-images.githubusercontent.com/3942712/38135825-9cc3bb9c-341a-11e8-8003-41bde02cb669.png)

After :
![image](https://user-images.githubusercontent.com/3942712/38135866-d6de939c-341a-11e8-98e7-c76526551385.png)

After using PDF Reader :
![image](https://user-images.githubusercontent.com/3942712/38137400-ae8a7b18-3424-11e8-8d6b-67e3b8cfbdd7.png)
