### PR TITLE
Issue with lower-roman style

### DIFF
--- a/src/Html2Pdf.php
+++ b/src/Html2Pdf.php
@@ -1181,8 +1181,8 @@ class Html2Pdf
      */
     protected function _listeArab2Rom($nbArabic)
     {
-        $nbBaseTen  = array('I','X','C','M');
-        $nbBaseFive = array('V','L','D');
+        $nbBaseTen  = array('i','x','c','m');
+        $nbBaseFive = array('v','l','d');
         $nbRoman    = '';
 
         if ($nbArabic<1) {


### PR DESCRIPTION
Ordered list always creating upper-roman style if we specified lower-roman style.
This change will resolve that issue.