### PR TITLE
improving generation performances

### DIFF
--- a/src/Html2Pdf.php
+++ b/src/Html2Pdf.php
@@ -137,8 +137,9 @@ class Html2Pdf
     /**
      * @var Html2Pdf
      */
-    static protected $_subobj    = null;        // object html2pdf prepared in order to accelerate the creation of sub html2pdf
-    static protected $_tables    = array();     // static table to prepare the nested html tables
+    static protected $_subobj				= null;		// object html2pdf prepared in order to accelerate the creation of sub html2pdf
+    static protected $_tables				= array();	// static table to prepare the nested html tables
+	static protected $_tmpFilesAreCleaned	= false;	// flag : file cleaning is done
 
     /**
      * list of tag definitions
@@ -231,6 +232,21 @@ class Html2Pdf
 
         return $this;
     }
+	
+	/**
+	 * Default destructor.
+	 * Clean cache files once, at the end of the pdf generation
+	 * @public
+	 */
+	public function __destruct() {
+		if($this->_isSubPart || self::$_tmpFilesAreCleaned) return;
+		// remove all temporary files
+		$tmpfiles = glob(K_PATH_CACHE.'__tcpdf_*');
+		if (!empty($tmpfiles)) {
+			self::$_tmpFilesAreCleaned = true;
+			array_map('unlink', $tmpfiles);
+		}
+	}
 
     /**
      * Gets the detailed version as array

--- a/src/Html2Pdf.php
+++ b/src/Html2Pdf.php
@@ -241,7 +241,7 @@ class Html2Pdf
 	public function __destruct() {
 		if($this->_isSubPart || self::$_tmpFilesAreCleaned) return;
 		// remove all temporary files
-		$tmpfiles = glob(K_PATH_CACHE.'__tcpdf_*');
+		$tmpfiles = glob(K_PATH_CACHE.'__tcpdf_'.$this->pdf->getFileId().'_*');
 		if (!empty($tmpfiles)) {
 			self::$_tmpFilesAreCleaned = true;
 			array_map('unlink', $tmpfiles);

--- a/src/MyPdf.php
+++ b/src/MyPdf.php
@@ -64,6 +64,49 @@ class MyPdf extends \TCPDF
         $this->setCellPaddings(0, 0, 0, 0);
         $this->setCellMargins(0, 0, 0, 0);
     }
+	
+	/**
+	 * Default destructor.
+	 * OVERWRITE TCPDF __destruct
+	 * @public
+	 * @since 1.53.0.TC016
+	 */
+	public function __destruct() {
+		// cleanup
+		$this->_destroy(true);
+	}
+	
+	/**
+	 * OVERWRITE TCPDF _destroy
+	 * tcpdf 
+	 */
+	public function _destroy($destroyall=false, $preserve_objcopy=false) {
+		// restore internal encoding
+		if (isset($this->internal_encoding) AND !empty($this->internal_encoding)) {
+			mb_internal_encoding($this->internal_encoding);
+		}
+		$preserve = array(
+			'file_id',
+			'internal_encoding',
+			'state',
+			'bufferlen',
+			'buffer',
+			'cached_files',
+			'sign',
+			'signature_data',
+			'signature_max_length',
+			'byterange_string',
+			'tsa_timestamp',
+			'tsa_data'
+		);
+		foreach (array_keys(get_object_vars($this)) as $val) {
+			if ($destroyall OR !in_array($val, $preserve)) {
+				if ((!$preserve_objcopy OR ($val != 'objcopy')) AND ($val != 'file_id') AND isset($this->$val)) {
+					unset($this->$val);
+				}
+			}
+		}
+	}
 
     /**
      * Set the parameters for the automatic footer

--- a/src/MyPdf.php
+++ b/src/MyPdf.php
@@ -107,6 +107,15 @@ class MyPdf extends \TCPDF
 			}
 		}
 	}
+	
+	/**
+     * Get the private variable file_id, for cleaning tmp files
+	 * @access public
+     */
+	public function getFileId()
+	{
+		return $this->file_id;
+	}
 
     /**
      * Set the parameters for the automatic footer


### PR DESCRIPTION
Because Html2Pdf loop through html elements, and creates a lot of sub elements, each time a sub element is cleared, a complete scan of /tmp/ dir was made to delete temp files.
These modifs allow to make only ONE scan in /tmp/ dir, at the end of generation, to delete temp files.