### PR TITLE
Tag regex doesn't match some valid HTML tags

### DIFF
--- a/src/Parsing/TagParser.php
+++ b/src/Parsing/TagParser.php
@@ -210,8 +210,8 @@ class TagParser
         $param = array();
         $regexes = array(
             '([a-zA-Z0-9_]+)=([^"\'\s>]+)',  // read the parameters : name=value
-            '([a-zA-Z0-9_]+)=["]([^"]*)["]', // read the parameters : name="value"
-            "([a-zA-Z0-9_]+)=[']([^']*)[']"  // read the parameters : name='value'
+            '([a-zA-Z0-9_]+)=\s*["]([^"]*)["]', // read the parameters : name="value"
+            "([a-zA-Z0-9_]+)=\s*[']([^']*)[']"  // read the parameters : name='value'
         );
 
         foreach ($regexes as $regex) {


### PR DESCRIPTION
Some tags like
<div key=
"value">
While valid html do not get matched by the regex because of the newline between the = and the "value"

Edit allows for tags with quoted values to appear after multiple spaces or newlines as HTML allows