### PR TITLE
Allow usage of [[page_cu]] in css class names

### DIFF
--- a/src/Parsing/Css.php
+++ b/src/Parsing/Css.php
@@ -621,8 +621,17 @@ class Css
         $class = array();
         $tmp = isset($param['class']) ? strtolower(trim($param['class'])) : '';
         $tmp = explode(' ', $tmp);
+        
+        // replace some values
+        $toReplace = array(
+            '[[page_cu]]' => $this->pdf->getMyNumPage()
+        );
+        
         foreach ($tmp as $k => $v) {
             $v = trim($v);
+            if (strlen($v)>0) {
+                $v = str_replace(array_keys($toReplace), array_values($toReplace), $v);
+            }
             if ($v) {
                 $class[] = $v;
             }


### PR DESCRIPTION
This fixes #522 by allowing the usage of the current page number within a css class name. By using this we are allowed to apply different styling depending on which page we are.