### PR TITLE
check if arrays are array to fix compatibility with php7.4

### DIFF
--- a/src/Html2Pdf.php
+++ b/src/Html2Pdf.php
@@ -1753,16 +1753,16 @@ class Html2Pdf
             $inBL[1]-= $border['b']['width'];
         }
 
-        if ($inTL[0]<=0 || $inTL[1]<=0) {
+        if (!is_array($inTL) || $inTL[0]<=0 || $inTL[1]<=0) {
             $inTL = null;
         }
-        if ($inTR[0]<=0 || $inTR[1]<=0) {
+        if (!is_array($inTR) || $inTR[0]<=0 || $inTR[1]<=0) {
             $inTR = null;
         }
-        if ($inBR[0]<=0 || $inBR[1]<=0) {
+        if (!is_array($inBR) || $inBR[0]<=0 || $inBR[1]<=0) {
             $inBR = null;
         }
-        if ($inBL[0]<=0 || $inBL[1]<=0) {
+        if (!is_array($inBL) || $inBL[0]<=0 || $inBL[1]<=0) {
             $inBL = null;
         }
 


### PR DESCRIPTION
Fix for bug #530 (Html2Pdf@_drawRectangle throws "Trying to access array offset on value of type null error" on php7.4)