### PR TITLE
Fix encoding error which throws warnings

### DIFF
--- a/src/Html2Pdf.php
+++ b/src/Html2Pdf.php
@@ -1036,7 +1036,7 @@ class Html2Pdf
         if ($curr !== null && $sub->parsingHtml->code[$this->_parsePos]->getName() === 'write') {
             $txt = $sub->parsingHtml->code[$this->_parsePos]->getParam('txt');
             $txt = str_replace('[[page_cu]]', $sub->pdf->getMyNumPage($this->_page), $txt);
-            $sub->parsingHtml->code[$this->_parsePos]->setParam('txt', substr($txt, $curr + 1));
+            $sub->parsingHtml->code[$this->_parsePos]->setParam('txt', mb_substr($txt, $curr + 1, strlen($txt), 'UTF-8'));
         } else {
             $sub->_parsePos++;
         }

--- a/src/Html2Pdf.php
+++ b/src/Html2Pdf.php
@@ -1036,7 +1036,7 @@ class Html2Pdf
         if ($curr !== null && $sub->parsingHtml->code[$this->_parsePos]->getName() === 'write') {
             $txt = $sub->parsingHtml->code[$this->_parsePos]->getParam('txt');
             $txt = str_replace('[[page_cu]]', $sub->pdf->getMyNumPage($this->_page), $txt);
-            $sub->parsingHtml->code[$this->_parsePos]->setParam('txt', mb_substr($txt, $curr + 1, strlen($txt), 'UTF-8'));
+            $sub->parsingHtml->code[$this->_parsePos]->setParam('txt', mb_substr($txt, $curr + 1, mb_strlen($txt, 'UTF-8'), 'UTF-8'));
         } else {
             $sub->_parsePos++;
         }


### PR DESCRIPTION
Fix an encoding error which throws multiple warnings if the $txt containts something like "ÄTZEND"

```
Warning: array_map(): Expected parameter 2 to be an array, bool given in vendor\tecnickcom\tcpdf\include\tcpdf_fonts.php on line 2002

Warning: array_merge(): Expected parameter 2 to be an array, null given in \vendor\tecnickcom\tcpdf\include\tcpdf_fonts.php on line 2010

Warning: Invalid argument supplied for foreach() in \vendor\tecnickcom\tcpdf\tcpdf.php on line 4085

Warning: array_merge(): Expected parameter 1 to be an array, null given in vendor\tecnickcom\tcpdf\include\tcpdf_fonts.php on line 2010

Warning: array_merge(): Expected parameter 1 to be an array, null given in vendor\tecnickcom\tcpdf\include\tcpdf_fonts.php on line 2010

Warning: array_merge(): Expected parameter 1 to be an array, null given in vendor\tecnickcom\tcpdf\include\tcpdf_fonts.php on line 2010

Warning: array_merge(): Expected parameter 1 to be an array, null given in vendor\tecnickcom\tcpdf\include\tcpdf_fonts.php on line 2010

Warning: array_merge(): Expected parameter 1 to be an array, null given in vendor\tecnickcom\tcpdf\include\tcpdf_fonts.php on line 2010

Warning: array_merge(): Expected parameter 1 to be an array, null given in vendor\tecnickcom\tcpdf\include\tcpdf_fonts.php on line 2010

Warning: array_merge(): Expected parameter 1 to be an array, null given in vendor\tecnickcom\tcpdf\include\tcpdf_fonts.php on line 2010

Warning: array_merge(): Expected parameter 1 to be an array, null given in vendor\tecnickcom\tcpdf\include\tcpdf_fonts.php on line 2010

Warning: array_merge(): Expected parameter 1 to be an array, null given in vendor\tecnickcom\tcpdf\include\tcpdf_fonts.php on line 2010

Warning: array_merge(): Expected parameter 1 to be an array, null given in vendor\tecnickcom\tcpdf\include\tcpdf_fonts.php on line 2010

Warning: array_map(): Expected parameter 2 to be an array, bool given in vendor\tecnickcom\tcpdf\include\tcpdf_fonts.php on line 2002

Warning: array_merge(): Expected parameter 1 to be an array, null given in vendor\tecnickcom\tcpdf\include\tcpdf_fonts.php on line 2010

Warning: count(): Parameter must be an array or an object that implements Countable in vendor\tecnickcom\tcpdf\include\tcpdf_fonts.php on line 1800

Warning: count(): Parameter must be an array or an object that implements Countable in vendor\tecnickcom\tcpdf\tcpdf.php on line 5268

Warning: array_map(): Expected parameter 2 to be an array, bool given in vendor\tecnickcom\tcpdf\include\tcpdf_fonts.php on line 2002

Warning: array_merge(): Expected parameter 1 to be an array, null given in vendor\tecnickcom\tcpdf\include\tcpdf_fonts.php on line 2010

Warning: Invalid argument supplied for foreach() in vendor\tecnickcom\tcpdf\tcpdf.php on line 4085
```