### PR TITLE
Update dependency version of tecnickcom/tcpdf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^5.6 || ^7.0 || ^8.0",
         "ext-mbstring": "*",
         "ext-gd": "*",
-        "tecnickcom/tcpdf": "^6.2"
+        "tecnickcom/tcpdf": "^6.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",


### PR DESCRIPTION
Current version used to require [tecnickcom/tcpdf](https://github.com/tecnickcom/TCPDF) doesn't support PHP8. Version `6.3.5` does (although with deprecation warnings, but it works)