### PR TITLE
Use multibyte aware substr when setting newline position

### DIFF
--- a/src/Html2Pdf.php
+++ b/src/Html2Pdf.php
@@ -1036,7 +1036,7 @@ class Html2Pdf
         if ($curr !== null && $sub->parsingHtml->code[$this->_parsePos]->getName() === 'write') {
             $txt = $sub->parsingHtml->code[$this->_parsePos]->getParam('txt');
             $txt = str_replace('[[page_cu]]', $sub->pdf->getMyNumPage($this->_page), $txt);
-            $sub->parsingHtml->code[$this->_parsePos]->setParam('txt', substr($txt, $curr + 1));
+            $sub->parsingHtml->code[$this->_parsePos]->setParam('txt', mb_substr($txt, $curr + 1, null, $this->_encoding));
         } else {
             $sub->_parsePos++;
         }


### PR DESCRIPTION
In instances where content containing UTF-8 characters overflows a line (causing an automatic linebreak), the subsequent shift in the content can cause invalid data to be sent to TCPDF. This causes a preg_split in that library to fail and thus produce PHP warnings.

An example of this that we've managed to replicate is where a sequence of no break spaces (C2A0) is broken up - the substr call causes the C2 byte to be chopped off and the new string to start A0, which is invalid.

This attempts to fix that issue by making the substr call multibyte aware.