### PR TITLE
fix mb_substr error for valid utf-8 encoded string

### DIFF
--- a/src/Html2Pdf.php
+++ b/src/Html2Pdf.php
@@ -1036,6 +1036,9 @@ class Html2Pdf
         if ($curr !== null && $sub->parsingHtml->code[$this->_parsePos]->getName() === 'write') {
             $txt = $sub->parsingHtml->code[$this->_parsePos]->getParam('txt');
             $txt = str_replace('[[page_cu]]', $sub->pdf->getMyNumPage($this->_page), $txt);
+            if ($this->_encoding == 'UTF-8') {
+                $txt = utf8_encode($txt);
+            }
             $sub->parsingHtml->code[$this->_parsePos]->setParam('txt', mb_substr($txt, $curr + 1, null, $this->_encoding));
         } else {
             $sub->_parsePos++;


### PR DESCRIPTION
see #693 