### PR TITLE
Added compatibility with PHPUnit 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,10 @@
 
 # PhpUnit
 /build/
+/.phpunit.result.cache
 
 # Composer
 /bin/
 /vendor/
 /composer.lock
+/composer.phar

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "tecnickcom/tcpdf": "^6.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0"
+        "phpunit/phpunit": "^5.0 || ^9.0"
     },
     "suggest": {
         "fagundes/zff-html2pdf": "if you need to integrate Html2Pdf with Zend Framework 2 (zf2)",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-     bootstrap="./vendor/autoload.php" colors="true" backupGlobals="false"
+     bootstrap="./src/Tests/bootstrap.php"
+     colors="true"
+     backupGlobals="false"
      backupStaticAttributes="false"
      verbose="true"
 >

--- a/src/Tests/AbstractTest.php
+++ b/src/Tests/AbstractTest.php
@@ -4,34 +4,17 @@ namespace Spipu\Html2Pdf\Tests;
 
 use Spipu\Html2Pdf\Html2Pdf;
 
+if (HTML2PDF_PHPUNIT_VERSION === 9) {
+    require_once 'CrossVersionCompatibility/PhpUnit9/AbstractTestCase.php';
+} else {
+    require_once 'CrossVersionCompatibility/PhpUnit5/AbstractTestCase.php';
+}
+
 /**
- * Class Html2PdfTest
+ * Class AbstractTest
  */
-abstract class AbstractTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractTest extends \Spipu\Html2Pdf\Tests\CrossVersionCompatibility\AbstractTestCase
 {
-    /**
-     * @var Html2Pdf
-     */
-    private $html2pdf;
-
-    /**
-     * Executed before each test
-     */
-    protected function setUp()
-    {
-        $this->html2pdf = new Html2Pdf('P', 'A4', 'fr', true, 'UTF-8', [0, 0, 0, 0]);
-        $this->html2pdf->pdf->SetTitle('PhpUnit Test');
-    }
-
-    /**
-     * Executed after each test
-     */
-    protected function tearDown()
-    {
-        $this->html2pdf->clean();
-        $this->html2pdf = null;
-    }
-
     /**
      * Get the object to test
      *

--- a/src/Tests/CrossVersionCompatibility/PhpUnit5/AbstractTestCase.php
+++ b/src/Tests/CrossVersionCompatibility/PhpUnit5/AbstractTestCase.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Spipu\Html2Pdf\Tests\CrossVersionCompatibility;
+
+use Spipu\Html2Pdf\Html2Pdf;
+
+abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Html2Pdf
+     */
+    protected $html2pdf;
+
+    /**
+     * Executed before each test
+     */
+    protected function setUp()
+    {
+        $this->html2pdf = new Html2Pdf('P', 'A4', 'fr', true, 'UTF-8', [0, 0, 0, 0]);
+        $this->html2pdf->pdf->SetTitle('PhpUnit Test');
+    }
+
+    /**
+     * Executed after each test
+     */
+    protected function tearDown()
+    {
+        $this->html2pdf->clean();
+        $this->html2pdf = null;
+    }
+
+    public function expectException($exception)
+    {
+        if (method_exists(\PHPUnit_Framework_TestCase::class, 'setExpectedException')) {
+            $this->setExpectedException($exception);
+        }
+    }
+
+    public function expectExceptionMessage($message, $exception = null)
+    {
+        if (method_exists(\PHPUnit_Framework_TestCase::class, 'expectExceptionMessage')) {
+            parent::expectExceptionMessage($message);
+        } elseif (method_exists(\PHPUnit_Framework_TestCase::class, 'setExpectedException')) {
+            $this->setExpectedException($exception, $message);
+        }
+    }
+}

--- a/src/Tests/CrossVersionCompatibility/PhpUnit5/CssConverterTestCase.php
+++ b/src/Tests/CrossVersionCompatibility/PhpUnit5/CssConverterTestCase.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spipu\Html2Pdf\Tests\CrossVersionCompatibility;
+
+use Spipu\Html2Pdf\CssConverter;
+
+abstract class CssConverterTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CssConverter
+     */
+    protected $cssConverter;
+
+    public function setUp()
+    {
+        $this->cssConverter = new CssConverter();
+    }
+}

--- a/src/Tests/CrossVersionCompatibility/PhpUnit5/ExceptionFormatterTestCase.php
+++ b/src/Tests/CrossVersionCompatibility/PhpUnit5/ExceptionFormatterTestCase.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Html2Pdf Library - Tests
+ *
+ * HTML => PDF converter
+ * distributed under the OSL-3.0 License
+ *
+ * @package   Html2pdf
+ * @author    Laurent MINGUET <webmaster@html2pdf.fr>
+ * @copyright 2017 Laurent MINGUET
+ */
+
+namespace Spipu\Html2Pdf\Tests\CrossVersionCompatibility;
+
+abstract class ExceptionFormatterTestCase extends \PHPUnit_Framework_TestCase
+{
+}

--- a/src/Tests/CrossVersionCompatibility/PhpUnit5/HtmlTestCase.php
+++ b/src/Tests/CrossVersionCompatibility/PhpUnit5/HtmlTestCase.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Html2Pdf Library - Tests
+ *
+ * HTML => PDF converter
+ * distributed under the OSL-3.0 License
+ *
+ * @package   Html2pdf
+ * @author    Laurent MINGUET <webmaster@html2pdf.fr>
+ * @copyright 2017 Laurent MINGUET
+ */
+
+namespace Spipu\Html2Pdf\Tests\CrossVersionCompatibility;
+
+use Spipu\Html2Pdf\Parsing\Html;
+
+abstract class HtmlTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Html
+     */
+    protected $object;
+
+    protected function setUp()
+    {
+        $textParser = $this->getMockBuilder('Spipu\Html2Pdf\Parsing\TextParser')
+            ->disableOriginalConstructor()
+            ->setMethods(['prepareTxt'])
+            ->getMock();
+
+        $textParser
+            ->expects($this->any())
+            ->method('prepareTxt')
+            ->will($this->returnCallback([$this, 'mockPrepareTxt']));
+
+        $this->object = new Html($textParser);
+    }
+}

--- a/src/Tests/CrossVersionCompatibility/PhpUnit5/SvgDrawerTestCase.php
+++ b/src/Tests/CrossVersionCompatibility/PhpUnit5/SvgDrawerTestCase.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spipu\Html2Pdf\Tests\CrossVersionCompatibility;
+
+use Spipu\Html2Pdf\CssConverter;
+use Spipu\Html2Pdf\SvgDrawer;
+
+abstract class SvgDrawerTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SvgDrawer
+     */
+    protected $svgDrawer;
+
+    public function setUp()
+    {
+        $myPdf = $this->createMock('Spipu\Html2Pdf\MyPdf');
+
+        $cssConverter = new CssConverter();
+
+        $this->svgDrawer = new SvgDrawer($myPdf, $cssConverter);
+    }
+}

--- a/src/Tests/CrossVersionCompatibility/PhpUnit5/TagParserTestCase.php
+++ b/src/Tests/CrossVersionCompatibility/PhpUnit5/TagParserTestCase.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Html2Pdf Library - Tests
+ *
+ * HTML => PDF converter
+ * distributed under the OSL-3.0 License
+ *
+ * @package   Html2pdf
+ * @author    Laurent MINGUET <webmaster@html2pdf.fr>
+ * @copyright 2017 Laurent MINGUET
+ */
+
+namespace Spipu\Html2Pdf\Tests\CrossVersionCompatibility;
+
+use Spipu\Html2Pdf\Parsing\Node;
+use Spipu\Html2Pdf\Parsing\TagParser;
+
+abstract class TagParserTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var TagParser
+     */
+    protected $parser;
+
+    protected function setUp()
+    {
+        $textParser = $this->getMockBuilder('Spipu\Html2Pdf\Parsing\TextParser')
+            ->disableOriginalConstructor()
+            ->setMethods(['prepareTxt'])
+            ->getMock();
+
+        $textParser
+            ->expects($this->any())
+            ->method('prepareTxt')
+            ->will($this->returnCallback([$this, 'mockPrepareTxt']));
+
+        $this->parser = new TagParser($textParser);
+    }
+}

--- a/src/Tests/CrossVersionCompatibility/PhpUnit5/TextParserTestCase.php
+++ b/src/Tests/CrossVersionCompatibility/PhpUnit5/TextParserTestCase.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Html2Pdf Library - Tests
+ *
+ * HTML => PDF converter
+ * distributed under the OSL-3.0 License
+ *
+ * @package   Html2pdf
+ * @author    Laurent MINGUET <webmaster@html2pdf.fr>
+ * @copyright 2017 Laurent MINGUET
+ */
+
+namespace Spipu\Html2Pdf\Tests\CrossVersionCompatibility;
+
+use Spipu\Html2Pdf\Parsing\TextParser;
+
+abstract class TextParserTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var TextParser
+     */
+    protected $parser;
+
+    protected function setUp()
+    {
+        $this->parser = new TextParser();
+    }
+}

--- a/src/Tests/CrossVersionCompatibility/PhpUnit9/AbstractTestCase.php
+++ b/src/Tests/CrossVersionCompatibility/PhpUnit9/AbstractTestCase.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Spipu\Html2Pdf\Tests\CrossVersionCompatibility;
+
+use Spipu\Html2Pdf\Html2Pdf;
+
+abstract class AbstractTestCase extends \PHPUnit\Framework\TestCase
+{
+    use \Spipu\Html2Pdf\Tests\CrossVersionCompatibility\PhpUnit9\AssertContains;
+
+    /**
+     * @var Html2Pdf
+     */
+    protected $html2pdf;
+
+    /**
+     * Executed before each test
+     */
+    protected function setUp(): void
+    {
+        $this->html2pdf = new Html2Pdf('P', 'A4', 'fr', true, 'UTF-8', [0, 0, 0, 0]);
+        $this->html2pdf->pdf->SetTitle('PhpUnit Test');
+    }
+
+    /**
+     * Executed after each test
+     */
+    protected function tearDown(): void
+    {
+        $this->html2pdf->clean();
+        $this->html2pdf = null;
+    }
+
+    public function expectExceptionMessage($message, $exception = null): void
+    {
+        // Yes, we ignore $exception
+        parent::expectExceptionMessage($message);
+    }
+}

--- a/src/Tests/CrossVersionCompatibility/PhpUnit9/AssertContains.php
+++ b/src/Tests/CrossVersionCompatibility/PhpUnit9/AssertContains.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spipu\Html2Pdf\Tests\CrossVersionCompatibility\PhpUnit9;
+
+trait AssertContains
+{
+    public static function assertContains($needle, $haystack, string $message = ''): void
+    {
+        if (is_string($haystack)) {
+            parent::assertStringContainsString($needle, $haystack, $message);
+        } else {
+            parent::assertContains($needle, $haystack, $message);
+        }
+    }
+}

--- a/src/Tests/CrossVersionCompatibility/PhpUnit9/CssConverterTestCase.php
+++ b/src/Tests/CrossVersionCompatibility/PhpUnit9/CssConverterTestCase.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spipu\Html2Pdf\Tests\CrossVersionCompatibility;
+
+use Spipu\Html2Pdf\CssConverter;
+
+abstract class CssConverterTestCase extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var CssConverter
+     */
+    protected $cssConverter;
+
+    public function setUp(): void
+    {
+        $this->cssConverter = new CssConverter();
+    }
+}

--- a/src/Tests/CrossVersionCompatibility/PhpUnit9/ExceptionFormatterTestCase.php
+++ b/src/Tests/CrossVersionCompatibility/PhpUnit9/ExceptionFormatterTestCase.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Html2Pdf Library - Tests
+ *
+ * HTML => PDF converter
+ * distributed under the OSL-3.0 License
+ *
+ * @package   Html2pdf
+ * @author    Laurent MINGUET <webmaster@html2pdf.fr>
+ * @copyright 2017 Laurent MINGUET
+ */
+
+namespace Spipu\Html2Pdf\Tests\CrossVersionCompatibility;
+
+abstract class ExceptionFormatterTestCase extends \PHPUnit\Framework\TestCase
+{
+    use \Spipu\Html2Pdf\Tests\CrossVersionCompatibility\PhpUnit9\AssertContains;
+}

--- a/src/Tests/CrossVersionCompatibility/PhpUnit9/HtmlTestCase.php
+++ b/src/Tests/CrossVersionCompatibility/PhpUnit9/HtmlTestCase.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Html2Pdf Library - Tests
+ *
+ * HTML => PDF converter
+ * distributed under the OSL-3.0 License
+ *
+ * @package   Html2pdf
+ * @author    Laurent MINGUET <webmaster@html2pdf.fr>
+ * @copyright 2017 Laurent MINGUET
+ */
+
+namespace Spipu\Html2Pdf\Tests\CrossVersionCompatibility;
+
+use Spipu\Html2Pdf\Parsing\Html;
+
+abstract class HtmlTestCase extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var Html
+     */
+    protected $object;
+
+    protected function setUp(): void
+    {
+        $textParser = $this->getMockBuilder('Spipu\Html2Pdf\Parsing\TextParser')
+            ->disableOriginalConstructor()
+            ->setMethods(['prepareTxt'])
+            ->getMock();
+
+        $textParser
+            ->expects($this->any())
+            ->method('prepareTxt')
+            ->willReturnCallback([$this, 'mockPrepareTxt']);
+
+        $this->object = new Html($textParser);
+    }
+}

--- a/src/Tests/CrossVersionCompatibility/PhpUnit9/SvgDrawerTestCase.php
+++ b/src/Tests/CrossVersionCompatibility/PhpUnit9/SvgDrawerTestCase.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spipu\Html2Pdf\Tests\CrossVersionCompatibility;
+
+use Spipu\Html2Pdf\CssConverter;
+use Spipu\Html2Pdf\SvgDrawer;
+
+abstract class SvgDrawerTestCase extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var SvgDrawer
+     */
+    protected $svgDrawer;
+
+    public function setUp(): void
+    {
+        $myPdf = $this->createMock('Spipu\Html2Pdf\MyPdf');
+
+        $cssConverter = new CssConverter();
+
+        $this->svgDrawer = new SvgDrawer($myPdf, $cssConverter);
+    }
+}

--- a/src/Tests/CrossVersionCompatibility/PhpUnit9/TagParserTestCase.php
+++ b/src/Tests/CrossVersionCompatibility/PhpUnit9/TagParserTestCase.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Html2Pdf Library - Tests
+ *
+ * HTML => PDF converter
+ * distributed under the OSL-3.0 License
+ *
+ * @package   Html2pdf
+ * @author    Laurent MINGUET <webmaster@html2pdf.fr>
+ * @copyright 2017 Laurent MINGUET
+ */
+
+namespace Spipu\Html2Pdf\Tests\CrossVersionCompatibility;
+
+use Spipu\Html2Pdf\Parsing\TagParser;
+
+abstract class TagParserTestCase extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var TagParser
+     */
+    protected $parser;
+
+    protected function setUp(): void
+    {
+        $textParser = $this->getMockBuilder('Spipu\Html2Pdf\Parsing\TextParser')
+            ->disableOriginalConstructor()
+            ->setMethods(['prepareTxt'])
+            ->getMock();
+
+        $textParser
+            ->expects($this->any())
+            ->method('prepareTxt')
+            ->willReturnCallback([$this, 'mockPrepareTxt']);
+
+        $this->parser = new TagParser($textParser);
+    }
+}

--- a/src/Tests/CrossVersionCompatibility/PhpUnit9/TestCase.php
+++ b/src/Tests/CrossVersionCompatibility/PhpUnit9/TestCase.php
@@ -1,0 +1,5 @@
+<?php
+
+class PHPUnit_Framework_TestCase extends PHPUnit\Framework\TestCase
+{
+}

--- a/src/Tests/CrossVersionCompatibility/PhpUnit9/TextParserTestCase.php
+++ b/src/Tests/CrossVersionCompatibility/PhpUnit9/TextParserTestCase.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Html2Pdf Library - Tests
+ *
+ * HTML => PDF converter
+ * distributed under the OSL-3.0 License
+ *
+ * @package   Html2pdf
+ * @author    Laurent MINGUET <webmaster@html2pdf.fr>
+ * @copyright 2017 Laurent MINGUET
+ */
+
+namespace Spipu\Html2Pdf\Tests\CrossVersionCompatibility;
+
+use Spipu\Html2Pdf\Parsing\TextParser;
+
+abstract class TextParserTestCase extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var TextParser
+     */
+    protected $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new TextParser();
+    }
+}

--- a/src/Tests/CssConverterTest.php
+++ b/src/Tests/CssConverterTest.php
@@ -2,23 +2,17 @@
 
 namespace Spipu\Html2Pdf\Tests;
 
-use Spipu\Html2Pdf\CssConverter;
+if (HTML2PDF_PHPUNIT_VERSION === 9) {
+    require_once 'CrossVersionCompatibility/PhpUnit9/CssConverterTestCase.php';
+} else {
+    require_once 'CrossVersionCompatibility/PhpUnit5/CssConverterTestCase.php';
+}
 
 /**
  * Class CssConverterTest
  */
-class CssConverterTest extends \PHPUnit_Framework_TestCase
+class CssConverterTest extends \Spipu\Html2Pdf\Tests\CrossVersionCompatibility\CssConverterTestCase
 {
-    /**
-     * @var CssConverter
-     */
-    private $cssConverter;
-
-    public function setUp()
-    {
-        $this->cssConverter = new CssConverter();
-    }
-
     /**
      * @param string $css
      * @param string $old

--- a/src/Tests/ExamplesTest.php
+++ b/src/Tests/ExamplesTest.php
@@ -12,10 +12,20 @@
 
 namespace Spipu\Html2Pdf\Tests;
 
+if (HTML2PDF_PHPUNIT_VERSION === 9) {
+    abstract class BaseExamplesTest extends \PHPUnit\Framework\TestCase
+    {
+    }
+} else {
+    abstract class BaseExamplesTest extends \PHPUnit_Framework_TestCase
+    {
+    }
+}
+
 /**
  * Class ExamplesTest
  */
-class ExamplesTest extends \PHPUnit_Framework_TestCase
+class ExamplesTest extends BaseExamplesTest
 {
     /**
      * Launch a example

--- a/src/Tests/Exception/ExceptionFormatterTest.php
+++ b/src/Tests/Exception/ExceptionFormatterTest.php
@@ -18,10 +18,16 @@ use Spipu\Html2Pdf\Exception\HtmlParsingException;
 use Spipu\Html2Pdf\Exception\ImageException;
 use Spipu\Html2Pdf\Exception\LongSentenceException;
 
+if (HTML2PDF_PHPUNIT_VERSION === 9) {
+    require_once __DIR__ . '/../CrossVersionCompatibility/PhpUnit9/ExceptionFormatterTestCase.php';
+} else {
+    require_once __DIR__ . '/../CrossVersionCompatibility/PhpUnit5/ExceptionFormatterTestCase.php';
+}
+
 /**
  * Class ExceptionFormaterTest
  */
-class ExceptionFormatterTest extends \PHPUnit_Framework_TestCase
+class ExceptionFormatterTest extends \Spipu\Html2Pdf\Tests\CrossVersionCompatibility\ExceptionFormatterTestCase
 {
     /**
      * Test the formatter / generic exception

--- a/src/Tests/Exception/LongSentenceExceptionTest.php
+++ b/src/Tests/Exception/LongSentenceExceptionTest.php
@@ -23,10 +23,11 @@ class LongSentenceExceptionTest extends AbstractTest
      * test LongSentence Exception
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\LongSentenceException
      */
     public function testBug()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\LongSentenceException::class);
+
         $sentence = 'This is a sentence.';
         $bigSentence = $sentence;
         for ($k=0; $k<110; $k++) {

--- a/src/Tests/Html2PdfTest.php
+++ b/src/Tests/Html2PdfTest.php
@@ -31,14 +31,15 @@ class Html2PdfTest extends AbstractTest
         $object->writeHTML('<div><img src="https://www.spipu.net/res/logo_spipu.gif" alt="" /></div>');
         $object->writeHTML('<div><img src="/temp/test.jpg" alt="" /></div>');
         $object->writeHTML('<div><img src="c:/temp/test.jpg" alt="" /></div>');
+
+        // Ensures we assert something
+        $this->assertTrue(true);
     }
 
-    /**
-     * @expectedException \Spipu\Html2Pdf\Exception\HtmlParsingException
-     * @expectedExceptionMessage Unauthorized path scheme
-     */
     public function testSecurityKo()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\HtmlParsingException::class);
+        $this->expectExceptionMessage('Unauthorized path scheme', \Spipu\Html2Pdf\Exception\HtmlParsingException::class);
         $object = $this->getObject();
         $object->writeHTML('<div><img src="phar://test.com/php.phar" alt="" /></div>');
     }

--- a/src/Tests/Image/BackgroundErrorTest.php
+++ b/src/Tests/Image/BackgroundErrorTest.php
@@ -24,10 +24,10 @@ class BackgroundErrorTest extends AbstractTest
      * test: The image src is unknown
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\ImageException
      */
     public function testCase()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\ImageException::class);
         $image = '/res/wrong.png';
 
         try {

--- a/src/Tests/Image/SrcErrorTest.php
+++ b/src/Tests/Image/SrcErrorTest.php
@@ -25,10 +25,10 @@ class SrcErrorTest extends AbstractTest
      * test: The image src is unknown
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\ImageException
      */
     public function testCase()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\ImageException::class);
         $image = '/res/wrong.png';
 
         try {

--- a/src/Tests/LocaleTest.php
+++ b/src/Tests/LocaleTest.php
@@ -24,10 +24,10 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
      * test bad code
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\LocaleException
      */
     public function testBadCode()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\LocaleException::class);
         Locale::clean();
 
         try {
@@ -42,10 +42,10 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
      * test unknown code
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\LocaleException
      */
     public function testUnknownCode()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\LocaleException::class);
         Locale::clean();
         try {
             Locale::load('aa');

--- a/src/Tests/Output/FileNameOkTest.php
+++ b/src/Tests/Output/FileNameOkTest.php
@@ -55,10 +55,10 @@ class FileNameOkTest extends AbstractTest
      * test: the file extension must be PDF - Error
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\Html2PdfException
      */
     public function testError()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\Html2PdfException::class);
         $object = $this->getObject();
         $object->writeHTML('<p>Hello World</p>');
         $object->output('test.bad');

--- a/src/Tests/Parsing/HtmlTest.php
+++ b/src/Tests/Parsing/HtmlTest.php
@@ -12,33 +12,17 @@
 
 namespace Spipu\Html2Pdf\Tests\Parsing;
 
-use Spipu\Html2Pdf\Parsing\Html;
+if (HTML2PDF_PHPUNIT_VERSION === 9) {
+    require_once __DIR__ . '/../CrossVersionCompatibility/PhpUnit9/HtmlTestCase.php';
+} else {
+    require_once __DIR__ . '/../CrossVersionCompatibility/PhpUnit5/HtmlTestCase.php';
+}
 
 /**
  * Class HtmlTest
  */
-class HtmlTest extends \PHPUnit_Framework_TestCase
+class HtmlTest extends \Spipu\Html2Pdf\Tests\CrossVersionCompatibility\HtmlTestCase
 {
-    /**
-     * @var Html
-     */
-    private $object;
-
-    protected function setUp()
-    {
-        $textParser = $this->getMockBuilder('Spipu\Html2Pdf\Parsing\TextParser')
-            ->disableOriginalConstructor()
-            ->setMethods(['prepareTxt'])
-            ->getMock();
-
-        $textParser
-            ->expects($this->any())
-            ->method('prepareTxt')
-            ->will($this->returnCallback([$this, 'mockPrepareTxt']));
-
-        $this->object = new Html($textParser);
-    }
-
     /**
      * mock of prepareTxt method
      *

--- a/src/Tests/Parsing/ParsingTest.php
+++ b/src/Tests/Parsing/ParsingTest.php
@@ -24,10 +24,10 @@ class ParsingTest extends AbstractTest
      * test: The tag is unknown
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\HtmlParsingException
      */
     public function testUnknownTag()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\HtmlParsingException::class);
         $object = $this->getObject();
         $object->writeHTML('<bad_tag>Hello World</bad_tag>');
         $object->output('test.pdf', 'S');
@@ -37,10 +37,10 @@ class ParsingTest extends AbstractTest
      * test: Too many tag closures found
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\HtmlParsingException
      */
     public function testTooManyClosuresFound()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\HtmlParsingException::class);
         $object = $this->getObject();
         $object->writeHTML('<i><u>Hello</u></i></b>');
         $object->output('test.pdf', 'S');
@@ -50,10 +50,10 @@ class ParsingTest extends AbstractTest
      * test: Tags are closed in a wrong order
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\HtmlParsingException
      */
     public function testWrongClosedOrder()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\HtmlParsingException::class);
         $object = $this->getObject();
         $object->writeHTML('<b><u><i>Hello</u></i></b>');
         $object->output('test.pdf', 'S');
@@ -63,10 +63,10 @@ class ParsingTest extends AbstractTest
      * test: The following tag has not been closed
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\HtmlParsingException
      */
     public function testNotClosed()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\HtmlParsingException::class);
         $object = $this->getObject();
         $object->writeHTML('<b><i>Hello</i>');
         $object->output('test.pdf', 'S');
@@ -76,10 +76,10 @@ class ParsingTest extends AbstractTest
      * test: The following tags have not been closed
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\HtmlParsingException
      */
     public function testNotClosedMore()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\HtmlParsingException::class);
         $object = $this->getObject();
         $object->writeHTML('<b><u><i>Hello</i>');
         $object->output('test.pdf', 'S');
@@ -89,10 +89,10 @@ class ParsingTest extends AbstractTest
      * test: The HTML tag code provided is invalid
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\HtmlParsingException
      */
     public function testInvalidCode()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\HtmlParsingException::class);
         $object = $this->getObject();
         $object->writeHTML('<az1-r_h>Hello</az1-r_h>');
         $object->output('test.pdf', 'S');

--- a/src/Tests/Parsing/TagParserTest.php
+++ b/src/Tests/Parsing/TagParserTest.php
@@ -13,33 +13,18 @@
 namespace Spipu\Html2Pdf\Tests\Parsing;
 
 use Spipu\Html2Pdf\Parsing\Node;
-use Spipu\Html2Pdf\Parsing\TagParser;
+
+if (HTML2PDF_PHPUNIT_VERSION === 9) {
+    require_once __DIR__ . '/../CrossVersionCompatibility/PhpUnit9/TagParserTestCase.php';
+} else {
+    require_once __DIR__ . '/../CrossVersionCompatibility/PhpUnit5/TagParserTestCase.php';
+}
 
 /**
  * Class TagParserTest
  */
-class TagParserTest extends \PHPUnit_Framework_TestCase
+class TagParserTest extends \Spipu\Html2Pdf\Tests\CrossVersionCompatibility\TagParserTestCase
 {
-    /**
-     * @var TagParser
-     */
-    private $parser;
-
-    protected function setUp()
-    {
-        $textParser = $this->getMockBuilder('Spipu\Html2Pdf\Parsing\TextParser')
-            ->disableOriginalConstructor()
-            ->setMethods(['prepareTxt'])
-            ->getMock();
-
-        $textParser
-            ->expects($this->any())
-            ->method('prepareTxt')
-            ->will($this->returnCallback([$this, 'mockPrepareTxt']));
-
-        $this->parser = new TagParser($textParser);
-    }
-
     /**
      * mock of prepareTxt method
      *
@@ -83,11 +68,10 @@ class TagParserTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Test if a bad tag is detected
-     *
-     * @expectedException  \Spipu\Html2Pdf\Exception\HtmlParsingException
      */
     public function testAnalyzeTagBadTag()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\HtmlParsingException::class);
         $this->parser->analyzeTag('test');
     }
 

--- a/src/Tests/Parsing/TextParserTest.php
+++ b/src/Tests/Parsing/TextParserTest.php
@@ -12,23 +12,17 @@
 
 namespace Spipu\Html2Pdf\Tests\Parsing;
 
-use Spipu\Html2Pdf\Parsing\TextParser;
+if (HTML2PDF_PHPUNIT_VERSION === 9) {
+    require_once __DIR__ . '/../CrossVersionCompatibility/PhpUnit9/TextParserTestCase.php';
+} else {
+    require_once __DIR__ . '/../CrossVersionCompatibility/PhpUnit5/TextParserTestCase.php';
+}
 
 /**
  * Class TextParserTest
  */
-class TextParserTest extends \PHPUnit_Framework_TestCase
+class TextParserTest extends \Spipu\Html2Pdf\Tests\CrossVersionCompatibility\TextParserTestCase
 {
-    /**
-     * @var TextParser
-     */
-    private $parser;
-
-    protected function setUp()
-    {
-        $this->parser = new TextParser();
-    }
-
     /**
      * Test if it works
      */

--- a/src/Tests/SvgDrawerTest.php
+++ b/src/Tests/SvgDrawerTest.php
@@ -2,35 +2,23 @@
 
 namespace Spipu\Html2Pdf\Tests;
 
-use Spipu\Html2Pdf\CssConverter;
-use Spipu\Html2Pdf\SvgDrawer;
+if (HTML2PDF_PHPUNIT_VERSION === 9) {
+    require_once 'CrossVersionCompatibility/PhpUnit9/SvgDrawerTestCase.php';
+} else {
+    require_once 'CrossVersionCompatibility/PhpUnit5/SvgDrawerTestCase.php';
+}
 
 /**
- * Class Html2PdfTest
+ * Class SvgDrawerTest
  */
-class SvgDrawerTest extends \PHPUnit_Framework_TestCase
+class SvgDrawerTest extends \Spipu\Html2Pdf\Tests\CrossVersionCompatibility\SvgDrawerTestCase
 {
     /**
-     * @var SvgDrawer
-     */
-    private $svgDrawer;
-
-    public function setUp()
-    {
-        $myPdf = $this->createMock('Spipu\Html2Pdf\MyPdf');
-
-        $cssConverter = new CssConverter();
-
-        $this->svgDrawer = new SvgDrawer($myPdf, $cssConverter);
-    }
-
-    /**
      * Test IsDrawing Exception
-     *
-     * @expectedException \Spipu\Html2Pdf\Exception\HtmlParsingException
      */
     public function testIsDrawingException()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\HtmlParsingException::class);
         $properties = [
             'x' => 0,
             'y' => 0,

--- a/src/Tests/Tag/MustHaveTagsTest.php
+++ b/src/Tests/Tag/MustHaveTagsTest.php
@@ -43,10 +43,10 @@ class MustHaveTagsTest extends AbstractTest
      * test
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\HtmlParsingException
      */
     public function testNotEmptyThead()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\HtmlParsingException::class);
         $html = '<table>';
         $html.= '<thead></thead>';
         $html.= '<tbody><tr><td>World</td></tr></tbody>';
@@ -61,10 +61,10 @@ class MustHaveTagsTest extends AbstractTest
      * test
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\HtmlParsingException
      */
     public function testNotEmptyTfoot()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\HtmlParsingException::class);
         $html = '<table>';
         $html.= '<tfoot></tfoot>';
         $html.= '<tbody><tr><td>World</td></tr></tbody>';

--- a/src/Tests/Tag/Svg/CircleErrorTest.php
+++ b/src/Tests/Tag/Svg/CircleErrorTest.php
@@ -23,10 +23,10 @@ class CircleErrorTest extends AbstractTest
      * test
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\HtmlParsingException
      */
     public function testCase()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\HtmlParsingException::class);
         $object = $this->getObject();
         $object->writeHTML('<circle />');
         $object->output('test.pdf', 'S');

--- a/src/Tests/Tag/Svg/EllipseErrorTest.php
+++ b/src/Tests/Tag/Svg/EllipseErrorTest.php
@@ -23,10 +23,10 @@ class EllipseErrorTest extends AbstractTest
      * test
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\HtmlParsingException
      */
     public function testCase()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\HtmlParsingException::class);
         $object = $this->getObject();
         $object->writeHTML('<ellipse />');
         $object->output('test.pdf', 'S');

--- a/src/Tests/Tag/Svg/GErrorTest.php
+++ b/src/Tests/Tag/Svg/GErrorTest.php
@@ -23,10 +23,10 @@ class GErrorTest extends AbstractTest
      * test
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\HtmlParsingException
      */
     public function testCase()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\HtmlParsingException::class);
         $object = $this->getObject();
         $object->writeHTML('<g />');
         $object->output('test.pdf', 'S');

--- a/src/Tests/Tag/Svg/LineErrorTest.php
+++ b/src/Tests/Tag/Svg/LineErrorTest.php
@@ -23,10 +23,10 @@ class LineErrorTest extends AbstractTest
      * test
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\HtmlParsingException
      */
     public function testCase()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\HtmlParsingException::class);
         $object = $this->getObject();
         $object->writeHTML('<line />');
         $object->output('test.pdf', 'S');

--- a/src/Tests/Tag/Svg/PathErrorTest.php
+++ b/src/Tests/Tag/Svg/PathErrorTest.php
@@ -23,10 +23,10 @@ class PathErrorTest extends AbstractTest
      * test
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\HtmlParsingException
      */
     public function testCase()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\HtmlParsingException::class);
         $object = $this->getObject();
         $object->writeHTML('<path />');
         $object->output('test.pdf', 'S');

--- a/src/Tests/Tag/Svg/PathInvalidTest.php
+++ b/src/Tests/Tag/Svg/PathInvalidTest.php
@@ -23,10 +23,10 @@ class PathInvalidTest extends AbstractTest
      * test
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\HtmlParsingException
      */
     public function testCase()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\HtmlParsingException::class);
         $html = '
 <page>
     <draw style="width:150mm; height:100mm;">

--- a/src/Tests/Tag/Svg/PolygonErrorTest.php
+++ b/src/Tests/Tag/Svg/PolygonErrorTest.php
@@ -23,10 +23,10 @@ class PolygonErrorTest extends AbstractTest
      * test
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\HtmlParsingException
      */
     public function testCase()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\HtmlParsingException::class);
         $object = $this->getObject();
         $object->writeHTML('<polygon />');
         $object->output('test.pdf', 'S');

--- a/src/Tests/Tag/Svg/PolylineErrorTest.php
+++ b/src/Tests/Tag/Svg/PolylineErrorTest.php
@@ -23,10 +23,10 @@ class PolylineErrorTest extends AbstractTest
      * test
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\HtmlParsingException
      */
     public function testCase()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\HtmlParsingException::class);
         $object = $this->getObject();
         $object->writeHTML('<polyline />');
         $object->output('test.pdf', 'S');

--- a/src/Tests/Tag/Svg/RectErrorTest.php
+++ b/src/Tests/Tag/Svg/RectErrorTest.php
@@ -23,10 +23,10 @@ class RectErrorTest extends AbstractTest
      * test
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\HtmlParsingException
      */
     public function testCase()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\HtmlParsingException::class);
         $object = $this->getObject();
         $object->writeHTML('<rect />');
         $object->output('test.pdf', 'S');

--- a/src/Tests/Tag/TdTooLongTest.php
+++ b/src/Tests/Tag/TdTooLongTest.php
@@ -24,10 +24,10 @@ class TdTooLongTest extends AbstractTest
      * test
      *
      * @return void
-     * @expectedException \Spipu\Html2Pdf\Exception\TableException
      */
     public function testCase()
     {
+        $this->expectException(\Spipu\Html2Pdf\Exception\TableException::class);
         $sentence = 'Hello World ! ';
         $sentences = '';
         for ($k=0; $k<100; $k++) {

--- a/src/Tests/bootstrap.php
+++ b/src/Tests/bootstrap.php
@@ -1,0 +1,12 @@
+<?php
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+if (!class_exists('PHPUnit_Framework_TestCase')
+    && version_compare(phpversion(), '7.1') >= 0
+) {
+    define('HTML2PDF_PHPUNIT_VERSION', 9);
+    require_once 'CrossVersionCompatibility/PhpUnit9/TestCase.php';
+} else {
+    define('HTML2PDF_PHPUNIT_VERSION', 5);
+}


### PR DESCRIPTION
Tested under:
PHP 5.6.40 / PHPUnit 5.4.8
PHP 7.0.10 / PHPUnit 5.7.27
PHP 7.1.15 / PHPUnit 5.7.27
PHP 7.2.28 / PHPUnit 5.7.27
PHP 7.3.15 / PHPUnit 9.5.26
PHP 7.4.33 / PHPUnit 9.5.26
PHP 8.0.25 / PHPUnit 9.5.26
PHP 8.1.12 / PHPUnit 9.5.26

For PHP 8.1.12 (tecnickcom/tcpdf version 6.5.0), the tests pass, however we get some deprecation notices:
`Deprecated: Implicit conversion from float 25.5 to int loses precision in vendor\tecnickcom\tcpdf\include\barcodes\qrcode.php on line 895`
