### PR TITLE
Add attribute to allow dynamic properties

### DIFF
--- a/src/Html2Pdf.php
+++ b/src/Html2Pdf.php
@@ -29,6 +29,7 @@ use Spipu\Html2Pdf\Debug\Debug;
 
 require_once dirname(__FILE__) . '/config/tcpdf.config.php';
 
+#[\AllowDynamicProperties]
 class Html2Pdf
 {
     /**

--- a/src/MyPdf.php
+++ b/src/MyPdf.php
@@ -14,6 +14,7 @@ namespace Spipu\Html2Pdf;
 
 use Spipu\Html2Pdf\Exception\HtmlParsingException;
 
+#[\AllowDynamicProperties]
 class MyPdf extends \TCPDF
 {
     protected $_footerParam = array();


### PR DESCRIPTION
If you try to use the package in PHP 8.2, an error will be shown due to Dynamic Properties deprecation. I have added the attribute so it will still work.