### PR TITLE
Declaring properties to avoid deprecation notice in PHP8.2

### DIFF
--- a/src/Html2Pdf.php
+++ b/src/Html2Pdf.php
@@ -158,6 +158,11 @@ class Html2Pdf
     protected $extensionsLoaded = false;
 
     /**
+     * @var bool
+     */
+    private $_pdfa;
+
+    /**
      * class constructor
      *
      * @param string  $orientation page orientation, same as TCPDF

--- a/src/MyPdf.php
+++ b/src/MyPdf.php
@@ -28,6 +28,11 @@ class MyPdf extends \TCPDF
     const ARC_NB_SEGMENT = 8;
 
     /**
+     * @var float|mixed
+     */
+    private mixed $ws;
+
+    /**
      * class constructor
      *
      * @param string  $orientation page orientation, same as TCPDF
@@ -229,7 +234,6 @@ class MyPdf extends \TCPDF
     /**
      * set the Word Spacing
      *
-     * @param float word spacing
      * @access public
      */
     public function setWordSpacing($ws = 0.)


### PR DESCRIPTION
Dynamic declaration of properties is deprecated in PHP8.2

This PR declares $ws (white spacing) in MyPdf.php & $pdfa (PDF/A) in Html2Pdf.php