### PR TITLE
Fix PHP 8.4 deprecation warnings

### DIFF
--- a/src/Html2Pdf.php
+++ b/src/Html2Pdf.php
@@ -381,11 +381,11 @@ class Html2Pdf
     /**
      * set the debug mode to On
      *
-     * @param DebugInterface $debugObject
+     * @param DebugInterface|null $debugObject
      *
      * @return Html2Pdf $this
      */
-    public function setModeDebug(DebugInterface $debugObject = null)
+    public function setModeDebug($debugObject = null)
     {
         if (is_null($debugObject)) {
             $this->debug = new Debug();

--- a/src/Locale.php
+++ b/src/Locale.php
@@ -81,7 +81,12 @@ class Locale
         self::$list = array();
         $handle = fopen($file, 'r');
         while (!feof($handle)) {
-            $line = fgetcsv($handle);
+            if (PHP_VERSION >= 80400) {
+                // As of PHP 8.4.0, depending on the default value of escape is deprecated.
+                $line = fgetcsv($handle, null, ',', '"', '\\');
+            } else {
+                $line = fgetcsv($handle);
+            }
             if (!is_array($line) || count($line) !=2) {
                 continue;
             }


### PR DESCRIPTION
I started using this package with PHP 8.4 and it seems to work fine for my use cases.

However, I noticed the following deprecation warnings which should be fixed by this PR:
* implicitly nullable parameter types are deprecated (see https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
* `fgetcsv()`: depending on the default value of `escape` is deprecated (see https://www.php.net/manual/en/function.fgetcsv.php)