### PR TITLE
chore: upgrade TCPDF::$pdfa argument type as per upstream

### DIFF
--- a/src/Html2Pdf.php
+++ b/src/Html2Pdf.php
@@ -76,7 +76,7 @@ class Html2Pdf
     protected $_unicode          = true;        // means that the input text is unicode (default = true)
 
     /**
-     * @var bool
+     * @var false|int
      */
     protected $_pdfa;
 
@@ -171,7 +171,7 @@ class Html2Pdf
      * @param boolean $unicode     TRUE means that the input text is unicode (default = true)
      * @param string  $encoding    charset encoding; default is UTF-8
      * @param array   $margins     Default margins (left, top, right, bottom)
-     * @param boolean $pdfa        If TRUE set the document to PDF/A mode.
+     * @param false|int $pdfa        If TRUE set the document to PDF/A mode.
      *
      * @return Html2Pdf
      */
@@ -578,7 +578,7 @@ class Html2Pdf
 
         // call the output of TCPDF
         $output = $this->pdf->Output($name, $dest);
-        
+
         // close the pdf and clean up
         $this->clean();
 

--- a/src/MyPdf.php
+++ b/src/MyPdf.php
@@ -42,7 +42,7 @@ class MyPdf extends TCPDF
      * @param boolean $unicode     TRUE means that the input text is unicode (default = true)
      * @param string  $encoding    charset encoding; default is UTF-8
      * @param boolean $diskcache   if TRUE reduce the RAM memory usage by caching temporary data on filesystem (slower).
-     * @param boolean $pdfa        If TRUE set the document to PDF/A mode.
+     * @param false|int $pdfa        If TRUE set the document to PDF/A mode.
      * @access public
      */
     public function __construct(
@@ -267,7 +267,7 @@ class MyPdf extends TCPDF
         $cornerBL = null,
         $cornerBR = null
     ) {
-    
+
         // init the path
         $path = '';
 
@@ -1087,7 +1087,7 @@ class MyPdf extends TCPDF
         $drawFirst = true,
         $trans = false
     ) {
-    
+
         // if we want the no trigo direction : add 2PI to the begin angle, to invert the direction
         if (!$direction) {
             $angleBegin+= M_PI*2.;
@@ -1387,7 +1387,7 @@ class MyPdf extends TCPDF
         $page = null,
         $fontName = 'helvetica'
     ) {
-    
+
         // bookmark the Title if wanted
         if ($bookmarkTitle) {
             $this->Bookmark($titre, 0, -1);


### PR DESCRIPTION
TCPDF allows to either pass `false` or the PDF/A version (`1` / `3`) to the `$pdfa` constructor argument.