### PR TITLE
Refactor: use PHP_VERSION_ID for integer comparison instead of PHP_VERSION

### DIFF
--- a/src/Locale.php
+++ b/src/Locale.php
@@ -81,7 +81,7 @@ class Locale
         self::$list = array();
         $handle = fopen($file, 'r');
         while (!feof($handle)) {
-            if (PHP_VERSION >= 80400) {
+            if (PHP_VERSION_ID >= 80400) {
                 // As of PHP 8.4.0, depending on the default value of escape is deprecated.
                 $line = fgetcsv($handle, null, ',', '"', '\\');
             } else {


### PR DESCRIPTION
Replaced PHP_VERSION with PHP_VERSION_ID to ensure integer comparison when checking PHP version compatibility. This change prevents potential issues with string comparisons and ensures the condition is evaluated correctly.

Updated code:
- `if (PHP_VERSION >= 80400)` -> `if (PHP_VERSION_ID >= 80400)`

This change affects the logic for handling the fgetcsv function depending on the PHP version.