### PR TITLE
Fix tables getting moved to other pages and breaking styles

### DIFF
--- a/src/Html2Pdf.php
+++ b/src/Html2Pdf.php
@@ -3230,7 +3230,7 @@ class Html2Pdf
                 $this->_tag_open_BR(array());
             }
 
-            if ($h < $maxH && $endY >= $maxY && !$this->_isInOverflow) {
+            if ($h < $maxH && $endY >= $maxY && !$this->_isInOverflow && ((!isset($param['class']) || strpos($param['class'], 'html2pdf-same-page') === false))) {
                 $this->_setNewPage();
             }
 


### PR DESCRIPTION
The current implementation moves elements into new pages if they don't fit the current page. That seems like a fine implementation, except that it breaks tables positioning in some occasions. Currently big tables get moved to a second page leaving a huge blank space in the first page.

With this change you can add the css class `html2pdf-same-page` to the table's parent div and force the table to stay in position and move its rows into multiple pages if needed.

Current implementation:
![image](https://github.com/user-attachments/assets/b693fa1f-1dc7-400e-b056-dd92af07b876)

After this PR:
![image](https://github.com/user-attachments/assets/a7b82897-4b21-4869-af67-e0b0ff2ea9ba)
