### PR TITLE
Add support to Readonly on Input type Text and Textarea

### DIFF
--- a/src/Html2Pdf.php
+++ b/src/Html2Pdf.php
@@ -6051,6 +6051,7 @@ class Html2Pdf
 
         $prop['multiline'] = true;
         $prop['value'] = $level[0]->getParam('txt', '');
+        $prop['readonly'] = $param['readonly'] ?? false;
 
         $this->pdf->TextField($param['name'], $w, $h, $prop, array(), $x, $y);
 
@@ -6159,6 +6160,7 @@ class Html2Pdf
                 }
                 $h = $f*1.3;
                 $prop['value'] = $param['value'];
+                $prop['readonly'] = $param['readonly'] ?? false;
                 $this->pdf->TextField($name, $w, $h, $prop, array(), $x, $y);
                 break;
 


### PR DESCRIPTION
This pull request includes changes to the `src/Html2Pdf.php` file to add support for readonly fields in both TEXTAREA and INPUT HTML elements.

Enhancements to form field properties:

* [`src/Html2Pdf.php`](diffhunk://#diff-0b5f2923b1eda104fe912542a0ba24cd3d2a22449d3a59d1ebeb43df6eae29cdR6054): Added support for the `readonly` attribute in the `_tag_open_TEXTAREA` function, allowing TEXTAREA fields to be marked as readonly. MDN: [Textarea / Readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/text#readonly)
* [`src/Html2Pdf.php`](diffhunk://#diff-0b5f2923b1eda104fe912542a0ba24cd3d2a22449d3a59d1ebeb43df6eae29cdR6163): Added support for the `readonly` attribute in the `_tag_open_INPUT` function, allowing INPUT fields to be marked as readonly. MDN: [Input / Text / Readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/textarea#readonly)