### PR TITLE
Add readonly attribute support for input and textarea

### DIFF
--- a/src/Html2Pdf.php
+++ b/src/Html2Pdf.php
@@ -6051,6 +6051,7 @@ class Html2Pdf
 
         $prop['multiline'] = true;
         $prop['value'] = $level[0]->getParam('txt', '');
+        $prop['readonly'] = $param['readonly'] ?? false;
 
         $this->pdf->TextField($param['name'], $w, $h, $prop, array(), $x, $y);
 
@@ -6159,6 +6160,7 @@ class Html2Pdf
                 }
                 $h = $f*1.3;
                 $prop['value'] = $param['value'];
+                $prop['readonly'] = $param['readonly'] ?? false;
                 $this->pdf->TextField($name, $w, $h, $prop, array(), $x, $y);
                 break;
 


### PR DESCRIPTION
This pull request introduces support for the standard HTML `readonly` attribute on `<input>` and `<textarea>` form fields within the generated PDF. Currently, this attribute is ignored, preventing the creation of read-only form fields in the PDF output even when specified in the source HTML.

**Enhancements:**

The changes enable `html2pdf` to recognize the `readonly` attribute and apply the corresponding read-only flag to the PDF form fields:

* **`<textarea>`:** Modified the `_tag_open_TEXTAREA` method in `src/Html2Pdf.php` (around line 6054) to detect the `readonly` attribute and set the field properties accordingly.
* **`<input>`:** Modified the `_tag_open_INPUT` method in `src/Html2Pdf.php` (around line 6163) to detect the `readonly` attribute and set the field properties for applicable input types.

**References:**

* MDN Documentation for `<textarea>` `readonly` attribute: [https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#readonly)
* MDN Documentation for `<input>` `readonly` attribute: [https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#readonly)

**Note:**

I understand the importance of maintaining stability in the library's codebase. However, I encountered this limitation myself and wanted to share this solution, both for potential integration and to help others who might be facing the same issue with needing read-only fields in their generated PDFs.

Thank you for considering this contribution.